### PR TITLE
Prevent header and footer from covering content on really small screens

### DIFF
--- a/client/src/app/navbar/garden-navbar.component.html
+++ b/client/src/app/navbar/garden-navbar.component.html
@@ -21,11 +21,12 @@
     .title {
         color: gold;
         font-family: 'Comfortaa', cursive;
-        font-size: 27px;
+        font-size: 20px;
         font-weight: bold;
     }
     .top-navbar {
         background-color: maroon;
+        min-width: 320px;
     }
     .search-tab {
         color: #404D5B;

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -9,7 +9,7 @@
 
 </head>
 
-<body style="margin: 0; padding: 0; height: 100%;background-color:#f3eddc;">
+<body style="margin: 0; padding: 0; height: 100%;background-color:#f3eddc; min-width: 320px">
 
 <div id="container" style="min-height:100%; position:relative;">
     <div style=" padding-bottom: 104px; padding-top: 115px">

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -1,4 +1,4 @@
-<html style="margin: 0; padding: 0; height: 100%">
+<html>
 <head>
     <base href="/">
     <title>Digital Display Garden</title>
@@ -9,10 +9,10 @@
 
 </head>
 
-<body style="margin: 0; padding: 0; height: 100%;background-color:#f3eddc; min-width: 320px">
+<body style="">
 
-<div id="container" style="min-height:100%; position:relative;">
-    <div style=" padding-bottom: 104px; padding-top: 115px">
+<div id="container">
+    <div id="inner-body">
     <app>Loading...</app>
     </div>
 
@@ -38,6 +38,30 @@
 </body>
 
 <style>
+    html {
+        margin: 0;
+        padding: 0;
+        height: 100%
+    }
+
+    body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        background-color:#f3eddc;
+        min-width: 320px
+    }
+
+    /* IntelliJ lies: #container IS being used!!! */
+    #container {
+        min-height:100%;
+        position:relative;
+    }
+
+    #inner-body {
+        padding-bottom: 104px;
+        padding-top: 115px
+    }
     .info-text {
         padding-top: 5px;
         margin-bottom: 5px;

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -58,17 +58,39 @@
         position:relative;
     }
 
-    /* see comment above */
-    #inner-body {
-        padding-bottom: 104px;
-        padding-top: 115px
-    }
 
     /* see comment above */
     .info-text {
         padding-top: 5px;
         margin-bottom: 5px;
     }
+
+    /* see comment above */
+    #inner-body {
+        padding-top: 115px;
+    }
+
+    /* below this size, the buttons wrap */
+    @media (max-width: 333px) {
+        #inner-body {
+            padding-bottom: 168px;
+        }
+    }
+
+    /* in this range only the address is wrapped */
+    @media (max-width:351px) and (min-width: 334px){
+        #inner-body {
+            padding-bottom: 134px;
+        }
+    }
+
+    /* at this size and up, the footer has no wrapping */
+    @media (min-width:352px) {
+        #inner-body {
+            padding-bottom: 114px;
+        }
+    }
+
     footer {
         font-weight: bold;
         width: 100%;

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -58,10 +58,13 @@
         position:relative;
     }
 
+    /* see comment above */
     #inner-body {
         padding-bottom: 104px;
         padding-top: 115px
     }
+
+    /* see comment above */
     .info-text {
         padding-top: 5px;
         margin-bottom: 5px;


### PR DESCRIPTION
Three important changes here:
1. Set the `min-width` of the page so that screens smaller than `320px` will have a scrollbar rather than trying to adjust.
1. Shrink the size of the font in the header so that it fits in `320px`. 
1. Use media queries to adjust padding on the bottom of the div containing the app to be different depending on how much wrapping is happening in the footer.